### PR TITLE
Lifecycle policy update

### DIFF
--- a/terraform/aws/modules/ecr-lifecycle-policy/README.md
+++ b/terraform/aws/modules/ecr-lifecycle-policy/README.md
@@ -17,6 +17,8 @@
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_dev_image_limit"></a> [dev\_image\_limit](#input\_dev\_image\_limit) | the number of non-prod images to retain in the repo | `number` | `30` | no |
+| <a name="input_prod_image_limit"></a> [prod\_image\_limit](#input\_prod\_image\_limit) | the number of prod images to retain in the repo | `number` | `10` | no |
 | <a name="input_repository_name"></a> [repository\_name](#input\_repository\_name) | the name of the ecr repository to associate the lifecycle policy with | `string` | n/a | yes |
 
 # Outputs

--- a/terraform/aws/modules/ecr-lifecycle-policy/main.tf
+++ b/terraform/aws/modules/ecr-lifecycle-policy/main.tf
@@ -5,12 +5,12 @@ resource "aws_ecr_lifecycle_policy" "this" {
     "rules": [
         {
             "rulePriority": 1,
-            "description": "keep last ${prod_image_count} prod images",
+            "description": "keep last ${prod_image_limit} prod images",
             "selection": {
                 "tagStatus": "tagged",
                 "tagPrefixList": ["prod"],
                 "countType": "imageCountMoreThan",
-                "countNumber": var.prod_image_count
+                "countNumber": var.prod_image_limit
             },
             "action": {
                 "type": "expire"
@@ -18,11 +18,11 @@ resource "aws_ecr_lifecycle_policy" "this" {
         },
         {
             "rulePriority": 2,
-            "description": "keep latest ${dev_image_count} non prod images",
+            "description": "keep latest ${dev_image_limit} non prod images",
             "selection": {
                 "tagStatus": "any",
                 "countType": "imageCountMoreThan",
-                "countNumber": var.dev_image_count
+                "countNumber": var.dev_image_limit
             },
             "action": {
                 "type": "expire"

--- a/terraform/aws/modules/ecr-lifecycle-policy/main.tf
+++ b/terraform/aws/modules/ecr-lifecycle-policy/main.tf
@@ -5,12 +5,12 @@ resource "aws_ecr_lifecycle_policy" "this" {
     "rules": [
         {
             "rulePriority": 1,
-            "description": "keep last 10 prod images",
+            "description": "keep last ${prod_image_count} prod images",
             "selection": {
                 "tagStatus": "tagged",
                 "tagPrefixList": ["prod"],
                 "countType": "imageCountMoreThan",
-                "countNumber": 10
+                "countNumber": var.prod_image_count
             },
             "action": {
                 "type": "expire"
@@ -18,11 +18,11 @@ resource "aws_ecr_lifecycle_policy" "this" {
         },
         {
             "rulePriority": 2,
-            "description": "keep latest 30 non prod images",
+            "description": "keep latest ${dev_image_count} non prod images",
             "selection": {
                 "tagStatus": "any",
                 "countType": "imageCountMoreThan",
-                "countNumber": 30
+                "countNumber": var.dev_image_count
             },
             "action": {
                 "type": "expire"

--- a/terraform/aws/modules/ecr-lifecycle-policy/variables.tf
+++ b/terraform/aws/modules/ecr-lifecycle-policy/variables.tf
@@ -9,6 +9,7 @@ variable "dev_image_limit" {
   description = "the number of non-prod images to retain in the repo"
   sensitive   = false
   default = 30
+  nullable = false
 }
 
 variable "prod_image_limit" {
@@ -16,4 +17,5 @@ variable "prod_image_limit" {
   description = "the number of prod images to retain in the repo"
   sensitive   = false
   default = 10
+  nullable = false
 }

--- a/terraform/aws/modules/ecr-lifecycle-policy/variables.tf
+++ b/terraform/aws/modules/ecr-lifecycle-policy/variables.tf
@@ -3,3 +3,17 @@ variable "repository_name" {
   description = "the name of the ecr repository to associate the lifecycle policy with"
   sensitive   = false
 }
+
+variable "dev_image_limit" {
+  type        = number
+  description = "the number of non-prod images to retain in the repo"
+  sensitive   = false
+  default = 30
+}
+
+variable "prod_image_limit" {
+  type        = number
+  description = "the number of prod images to retain in the repo"
+  sensitive   = false
+  default = 10
+}

--- a/terraform/aws/modules/ecr-repository/README.md
+++ b/terraform/aws/modules/ecr-repository/README.md
@@ -36,12 +36,14 @@
 | <a name="input_create_lifecycle_policy"></a> [create\_lifecycle\_policy](#input\_create\_lifecycle\_policy) | whether to create a lifecycle policy for the ecr repository with standard expiration rules | `bool` | `true` | no |
 | <a name="input_customer_master_key_spec"></a> [customer\_master\_key\_spec](#input\_customer\_master\_key\_spec) | whether the key contains a symmetric key or an asymmetric key pair and the encryption algorithms or signing algorithms that the key supports | `string` | `"SYMMETRIC_DEFAULT"` | no |
 | <a name="input_deletion_window_in_days"></a> [deletion\_window\_in\_days](#input\_deletion\_window\_in\_days) | days before the key is permanently deleted after destruction of the resource | `number` | `7` | no |
+| <a name="input_dev_image_limit"></a> [dev\_image\_limit](#input\_dev\_image\_limit) | the number of non-prod images to retain in the repo | `number` | `null` | no |
 | <a name="input_env"></a> [env](#input\_env) | the target tier ('dev', 'qa', 'stage', 'nonprod' or 'prod'.) | `string` | n/a | yes |
 | <a name="input_force_delete"></a> [force\_delete](#input\_force\_delete) | whether to allow terraform to delete a repository, even if contains images | `bool` | `false` | no |
 | <a name="input_image_tag_mutability"></a> [image\_tag\_mutability](#input\_image\_tag\_mutability) | tag mutability setting for the repository - must be 'MUTABLE' or 'IMMUTABLE' | `string` | `"IMMUTABLE"` | no |
 | <a name="input_microservice"></a> [microservice](#input\_microservice) | name of the image, such as 'frontend', 'backend', or 'files' | `string` | n/a | yes |
 | <a name="input_nonprod_account_id"></a> [nonprod\_account\_id](#input\_nonprod\_account\_id) | the nonprod project account id - required if create\_access\_policy is true | `string` | `null` | no |
 | <a name="input_prod_account_id"></a> [prod\_account\_id](#input\_prod\_account\_id) | the prod project account id - required if create\_access\_policy is true | `string` | `null` | no |
+| <a name="input_prod_image_limit"></a> [prod\_image\_limit](#input\_prod\_image\_limit) | the number of prod images to retain in the repo | `number` | `null` | no |
 | <a name="input_tpm_email"></a> [tpm\_email](#input\_tpm\_email) | the email address of the technical project manager for the application | `string` | n/a | yes |
 | <a name="input_tpm_first_name"></a> [tpm\_first\_name](#input\_tpm\_first\_name) | the first name of the technical project manager for the application | `string` | n/a | yes |
 | <a name="input_tpm_last_name"></a> [tpm\_last\_name](#input\_tpm\_last\_name) | the last name of the technical project manager for the application | `string` | n/a | yes |

--- a/terraform/aws/modules/ecr-repository/main.tf
+++ b/terraform/aws/modules/ecr-repository/main.tf
@@ -26,6 +26,8 @@ module "lifecycle_policy" {
   source = "git::https://github.com/CBIIT/ccdi-devops.git//terraform/aws/modules/ecr-lifecycle-policy"
 
   repository_name = aws_ecr_repository.this.name
+  dev_image_limit = var.dev_image_limit
+  prod_image_limit = var.prod_image_limit
 }
 
 module "access_policy" {

--- a/terraform/aws/modules/ecr-repository/variables.tf
+++ b/terraform/aws/modules/ecr-repository/variables.tf
@@ -106,3 +106,17 @@ variable "tpm_last_name" {
   description = "the last name of the technical project manager for the application"
   sensitive   = false
 }
+
+variable "dev_image_limit" {
+  type        = number
+  description = "the number of non-prod images to retain in the repo"
+  sensitive   = false
+  default = null
+}
+
+variable "prod_image_limit" {
+  type        = number
+  description = "the number of prod images to retain in the repo"
+  sensitive   = false
+  default = null
+}


### PR DESCRIPTION
Adds the ability to set custom lifecycle policy for each repo. The dev_image_limit and prod_image_limit variables can be passed for a repo if it needs to deviate from the defaults. If values are passed for these vars they will override the defaults, if not the values in ecr-repository will be set to null which will cause the default values set in ecr-lifecycle-policy to be used